### PR TITLE
Update availability.js

### DIFF
--- a/availability.js
+++ b/availability.js
@@ -129,8 +129,8 @@ function parseDate (date) {
 
 function determineAvailability (date) {
   var diff = date - Date.now()
-  if (date && diff < MONTH) return AVAILABLE
-  if (date && diff < (10 * MONTH)) return SOON
+  if (date && diff < DAY) return AVAILABLE
+  if (date && diff < (10 * DAY)) return SOON
   return UNAVAILABLE
 }
 


### PR DESCRIPTION
This seems like the intended behavior. For the tool to say I'm "available" a month out and available "soon" up to 10 months out doesn't seem very logical.
